### PR TITLE
Add wait for juptyer

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,5 +12,6 @@
 disable=
     invalid-name,
     line-too-long,
+    logging-fstring-interpolation,
     too-many-arguments,
     too-many-locals

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -318,9 +318,9 @@ class SaturnConnection:
         start_time = datetime.utcnow()
 
         log.info(f"Waiting for Jupyter to be {target_status}...")
-        while (datetime.utcnow() - start_time).total_seconds < timeout:
+        while (datetime.utcnow() - start_time).total_seconds() < timeout:
             status = self.get_jupyter_server(jupyter_server_id)["status"]
-            time_passed = (datetime.utcnow() - start_time).total_seconds
+            time_passed = (datetime.utcnow() - start_time).total_seconds()
             log.info(f"Checking jupyter status: {status}({time_passed}/{timeout})")
             if status == target_status:
                 log.info(f"Jupyter server is {status}")

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -6,6 +6,7 @@ the future
 import json
 import logging
 
+from time import sleep
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -304,6 +305,22 @@ class SaturnConnection:
                 response.status_code, response.json()["message"] + _maybe_name(jupyter_server_id)
             ) from err
         return response.json()
+
+    def wait_for_jupyter_server(
+        self, jupyter_server_id, status="running", max_retries=30, sleep_interval=5
+    ):
+        """Wait for jupyter server to be at a particular status"""
+        log.info(f"Waiting for Jupyter to be {status}...")
+        retries_so_far = 0
+        while retries_so_far < max_retries:
+            retries_so_far += 1
+            result = self.get_jupyter_server(jupyter_server_id)
+            log.info(f"Checking jupyter status: {result['status']}({retries_so_far}/{max_retries})")
+            if result["status"] == status:
+                log.info(f"Jupyter server is {status}")
+                break
+            else:
+                sleep(sleep_interval)
 
     def stop_jupyter_server(self, jupyter_server_id: str) -> None:
         """Stop a particular jupyter server.

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -7,6 +7,7 @@ import json
 import logging
 
 from time import sleep
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -306,17 +307,22 @@ class SaturnConnection:
             ) from err
         return response.json()
 
-    def wait_for_jupyter_server(
-        self, jupyter_server_id, status="running", max_retries=30, sleep_interval=5
-    ):
-        """Wait for jupyter server to be at a particular status"""
-        log.info(f"Waiting for Jupyter to be {status}...")
-        retries_so_far = 0
-        while retries_so_far < max_retries:
-            retries_so_far += 1
-            result = self.get_jupyter_server(jupyter_server_id)
-            log.info(f"Checking jupyter status: {result['status']}({retries_so_far}/{max_retries})")
-            if result["status"] == status:
+    def wait_for_jupyter_server(self, jupyter_server_id, timeout=360):
+        """Wait for jupyter server to be running
+
+        :param jupyter_server_id: ID of the jupyter_server to wait for.
+        :param timeout: Time in seconds before the wait gives us. Default is 360.
+        """
+        target_status = "running"
+        sleep_interval = 5
+        start_time = datetime.utcnow()
+
+        log.info(f"Waiting for Jupyter to be {target_status}...")
+        while (datetime.utcnow() - start_time).total_seconds < timeout:
+            status = self.get_jupyter_server(jupyter_server_id)["status"]
+            time_passed = (datetime.utcnow() - start_time).total_seconds
+            log.info(f"Checking jupyter status: {status}({time_passed}/{timeout})")
+            if status == target_status:
                 log.info(f"Jupyter server is {status}")
                 break
             else:

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -307,11 +307,11 @@ class SaturnConnection:
             ) from err
         return response.json()
 
-    def wait_for_jupyter_server(self, jupyter_server_id, timeout=360):
+    def wait_for_jupyter_server(self, jupyter_server_id: str, timeout: int = 360) -> None:
         """Wait for jupyter server to be running
 
         :param jupyter_server_id: ID of the jupyter_server to wait for.
-        :param timeout: Time in seconds before the wait gives us. Default is 360.
+        :param timeout: Maximum time in seconds to wait. Default is 360 (6 minutes).
         """
         target_status = "running"
         sleep_interval = 5

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -326,7 +326,7 @@ class SaturnConnection:
                 break
             if status == "error":
                 raise AssertionError(
-                    f"Jupyter server has status: {status}. " "See logs in Saturn User Interface."
+                    f"Jupyter server has status: {status}. See logs in Saturn User Interface."
                 )
             sleep(sleep_interval)
             time_passed = (datetime.utcnow() - start_time).total_seconds()

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -325,7 +325,9 @@ class SaturnConnection:
                 log.info(f"Jupyter server is {status}")
                 break
             if status == "error":
-                raise AssertionError(f"Jupyter server is {status}")
+                raise AssertionError(
+                    f"Jupyter server has status: {status}. " "See logs in Saturn User Interface."
+                )
             sleep(sleep_interval)
             time_passed = (datetime.utcnow() - start_time).total_seconds()
             log.info(

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -324,7 +324,8 @@ class SaturnConnection:
             if status == target_status:
                 log.info(f"Jupyter server is {status}")
                 break
-
+            if status == "error":
+                raise AssertionError(f"Jupyter server is {status}")
             sleep(sleep_interval)
             time_passed = (datetime.utcnow() - start_time).total_seconds()
             log.info(

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -316,17 +316,21 @@ class SaturnConnection:
         target_status = "running"
         sleep_interval = 5
         start_time = datetime.utcnow()
+        time_passed = 0
 
         log.info(f"Waiting for Jupyter to be {target_status}...")
-        while (datetime.utcnow() - start_time).total_seconds() < timeout:
+        while time_passed < timeout:
             status = self.get_jupyter_server(jupyter_server_id)["status"]
-            time_passed = (datetime.utcnow() - start_time).total_seconds()
-            log.info(f"Checking jupyter status: {status}({time_passed}/{timeout})")
             if status == target_status:
                 log.info(f"Jupyter server is {status}")
                 break
-            else:
-                sleep(sleep_interval)
+
+            sleep(sleep_interval)
+            time_passed = (datetime.utcnow() - start_time).total_seconds()
+            log.info(
+                f"Checking jupyter status: {status} "
+                f"(seconds passed: {time_passed:.0f}/{timeout})"
+            )
 
     def stop_jupyter_server(self, jupyter_server_id: str) -> None:
         """Stop a particular jupyter server.


### PR DESCRIPTION
As recommended in #2, this adds the `wait_for_jupyter_server` method to poll status and check to see if it's running. I am fine with it being merged any time.