### PR TITLE
Print status with return char

### DIFF
--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -322,9 +322,10 @@ class SaturnConnection:
                 )
             sleep(sleep_interval)
             time_passed = (datetime.utcnow() - start_time).total_seconds()
-            log.info(
+            print(
                 f"Checking jupyter status: {status} "
-                f"(seconds passed: {time_passed:.0f}/{timeout})"
+                f"(seconds passed: {time_passed:.0f}/{timeout})",
+                end="\r",
             )
 
     def stop_jupyter_server(self, jupyter_server_id: str) -> None:

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -332,7 +332,7 @@ class SaturnConnection:
                 end="",
             )
             sleep(sleep_interval)
-        raise TimeoutError("Timed out wait for jupyter server")
+        raise TimeoutError("Timed out waiting for jupyter server")
 
     def stop_jupyter_server(self, jupyter_server_id: str) -> None:
         """Stop a particular jupyter server.


### PR DESCRIPTION
Cleaning up the output of wait_for_jupyter_server so that it doesn't spam logs. Also noticed that on timeout it would currently just return exactly like if it had reached state "running", so added a TimeoutError for that.

- Print status polling on a single line
- Newline on status change
- Throw exception on timeout

```
>>> saturn = SaturnConnection("https://app.daily.saturncloud.org", "<REDACTED>")
>>> saturn.wait_for_jupyter_server("fcd207e9aef64bc8b4c3951a35a3bf8c")
INFO:saturn-client:Waiting for Jupyter to be running...
Checking jupyter status: pending (seconds passed: 11/360)
INFO:saturn-client:Jupyter server is running
>>> saturn.stop_jupyter_server("fcd207e9aef64bc8b4c3951a35a3bf8c")
>>> saturn.wait_for_jupyter_server("fcd207e9aef64bc8b4c3951a35a3bf8c")
INFO:saturn-client:Waiting for Jupyter to be running...
Checking jupyter status: stopping (seconds passed: 26/360)
Checking jupyter status: stopped (seconds passed: 365/360)Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/bhperry/workspace/saturn-client/saturn_client/core.py", line 335, in wait_for_jupyter_server
    raise TimeoutError("Timed out wait for jupyter server")
TimeoutError: Timed out wait for jupyter server
```