### PR TITLE
client followup

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pip:
     - black
     - pre-commit
+    - ruamel-yaml

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -20,13 +20,16 @@ def cli():
     required=False,
     help="Resource owner name. Defaults to current auth identity.",
 )
-def list(resource_type: Optional[str], resource_name: Optional[str] = None, owner: str = None):
+def resources(resource_type: Optional[str], resource_name: Optional[str] = None, owner: str = None):
     """
-    List resources belonging to an owner. Resources are prefix
-    matched against RESOURCE_NAME, if set.
-    Pass "all" into RESOURCE_NAME to list unfiltered by type (default)
+    List resources belonging to an owner.
 
-    Resource Types: [workspace, deployment, job]
+    \b
+    RESOURCE_TYPE (optional):
+        all: List resources of any type (Default)
+        deployment, job, workspace: Filter for resources of a single type
+    RESOURCE_NAME (optional):
+        Filter results by prefix match on name
     """
     client = SaturnConnection()
     if resource_type == "all":
@@ -41,9 +44,13 @@ def list(resource_type: Optional[str], resource_name: Optional[str] = None, owne
 @click.option("--owner", default=None, required=False)
 def pods(resource_type: str, resource_name: str, owner: str = None):
     """
-    List pods associated with a resource.
+    List active pods associated with a resource.
 
-    Resource Types: [workspace, deployment, job]
+    \b
+    RESOURCE_TYPE (required):
+        deployment, job, workspace
+    RESOURCE_NAME (required):
+        Exact match on name
     """
     client = SaturnConnection()
     resource_type = ResourceType.lookup(resource_type)
@@ -61,23 +68,55 @@ def pods(resource_type: str, resource_name: str, owner: str = None):
     required=False,
     help="Resource owner name. Defaults to current auth identity.",
 )
-def logs(resource_type: str, resource_name: str, owner: str = None, pod_name: str = None):
+@click.option(
+    "-a",
+    "--all-containers",
+    default=False,
+    is_flag=True,
+    help=(
+        "Print logs for all containers. "
+        "By default, only logs for the main container are shown (or init containers during setup)"
+    ),
+)
+def logs(
+    resource_type: str,
+    resource_name: str,
+    owner: str = None,
+    pod_name: str = None,
+    all_containers: bool = False,
+):
     """
     Print resource logs. Defaults to the most recently created pod if POD_NAME is not given.
 
-    Resource Types: [workspace, deployment, job]
+    \b
+    RESOURCE_TYPE (required):
+        deployment, job, workspace
+    RESOURCE_NAME (required):
+        Exact match on name
+    POD_NAME (optional):
+        Fetch logs for a specific pod on the resource. Defaults to the latest pod.
     """
     client = SaturnConnection()
-    logs = client.get_logs(resource_type, resource_name, owner_name=owner, pod_name=pod_name)
+    logs = client.get_logs(
+        resource_type,
+        resource_name,
+        owner_name=owner,
+        pod_name=pod_name,
+        all_containers=all_containers,
+    )
     click.echo(logs)
 
 
 @cli.command()
 @click.argument("input-file")
-@click.option("--start", is_flag=True)
+@click.option("--start", is_flag=True, help="Start the resource after creating/updating it with the recipe")
 def apply(input_file: str, start: bool = False):
     """
     Create or update the contents of a resource recipe.
+
+    \b
+    INPUT_FILE (required):
+        Path to a YAML or JSON recipe file
     """
     with open(input_file, "r") as f:
         yaml = YAML()

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -1,10 +1,8 @@
-from typing import Optional
-
 from ruamel.yaml import YAML
 import click
 
 from saturn_client.cli.utils import print_resource_table, print_pod_table
-from saturn_client.core import SaturnConnection, ResourceType, SaturnHTTPError
+from saturn_client.core import SaturnConnection, ResourceType
 
 
 @click.group()
@@ -14,8 +12,18 @@ def cli():
 
 @cli.command()
 @click.argument("resource_type")
-@click.option("--owner", default=None, required=False)
+@click.option(
+    "--owner",
+    default=None,
+    required=False,
+    help="Resource owner name. Defaults to current auth identity.",
+)
 def list(resource_type: str, owner: str = None):
+    """
+    List resources belonging to an owner.
+
+    Resource Types: [workspace, deployment, job]
+    """
     client = SaturnConnection()
     resource_type = ResourceType.lookup(resource_type)
     resources = []
@@ -30,23 +38,38 @@ def list(resource_type: str, owner: str = None):
 
 @cli.command()
 @click.argument("resource_type")
-@click.argument("name")
+@click.argument("resource_name")
 @click.option("--owner", default=None, required=False)
-def pods(resource_type: str, name: str, owner: str = None):
+def pods(resource_type: str, resource_name: str, owner: str = None):
+    """
+    List pods associated with a resource.
+
+    Resource Types: [workspace, deployment, job]
+    """
     client = SaturnConnection()
     resource_type = ResourceType.lookup(resource_type)
-    pods = client.get_pods(resource_type, name, owner)
+    pods = client.get_pods(resource_type, resource_name, owner)
     print_pod_table(pods)
 
 
 @cli.command()
 @click.argument("resource_type")
-@click.argument("name")
+@click.argument("resource_name")
 @click.argument("pod_name", default=None, required=False)
-@click.option("--owner", default=None, required=False)
-def logs(resource_type: str, name: str, owner: str = None, pod_name: str = None):
+@click.option(
+    "--owner",
+    default=None,
+    required=False,
+    help="Resource owner name. Defaults to current auth identity.",
+)
+def logs(resource_type: str, resource_name: str, owner: str = None, pod_name: str = None):
+    """
+    Print resource logs. Defaults to the most recently created pod if POD_NAME is not given.
+
+    Resource Types: [workspace, deployment, job]
+    """
     client = SaturnConnection()
-    logs = client.get_logs(resource_type, name, owner_name=owner, pod_name=pod_name)
+    logs = client.get_logs(resource_type, resource_name, owner_name=owner, pod_name=pod_name)
     click.echo(logs)
 
 
@@ -54,6 +77,9 @@ def logs(resource_type: str, name: str, owner: str = None, pod_name: str = None)
 @click.argument("input-file")
 @click.option("--start", is_flag=True)
 def apply(input_file: str, start: bool = False):
+    """
+    Create or update the contents of a resource recipe.
+    """
     with open(input_file, "r") as f:
         yaml = YAML()
         obj = yaml.load(f)
@@ -63,8 +89,6 @@ def apply(input_file: str, start: bool = False):
         resource_type = ResourceType.lookup(result['type'])
         resource_id = result['state']['id']
         client._start(resource_type, resource_id)
-
-
 
 
 if __name__ == "__main__":

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -254,6 +254,42 @@ def restart(resource_type: str, resource_name: str, owner: Optional[str] = None,
     resource_id = resource["state"]["id"]
     client.restart(resource_type, resource_id, debug_mode=debug)
 
+@cli.command()
+@click.argument("job_name")
+@click.argument("cron_schedule", required=False, default=None)
+@click.option(
+    "--owner",
+    default=None,
+    required=False,
+    help="Resource owner name. Defaults to current auth identity.",
+)
+@click.option(
+    "--disable",
+    is_flag=True,
+    help="Disable scheduling for the job"
+)
+def schedule(job_name: str, cron_schedule: Optional[str] = None, owner: Optional[str] = None, disable: bool = False):
+    """
+    Enable or disable scheduling for a job. If CRON_SCHEDULE is not given, then it
+    is assumed that the job already has a cron schedule set.
+
+    \b
+    JOB_NAME (required):
+        Exact match on name
+    CRON_SCHEDULE (optional):
+        Update the job's schedule before enabling. May be provided in cron format, or using special @ tags.
+            Predefined: @hourly, @daily, @midnight, @weekly, @monthly, @yearly
+            Interval: @every <duration> (e.g. "@every 4h")
+    """
+    client = SaturnConnection()
+    resource = client.get_resource(ResourceType.JOB, job_name, owner_name=owner)
+    job_id = resource["state"]["id"]
+    client.schedule(job_id, cron_schedule=cron_schedule, disable=disable)
+    print_resource_op(
+        "Unscheduled" if disable else "Scheduled", ResourceType.JOB, job_name, owner
+    )
+
+
 if __name__ == "__main__":
     try:
         cli(max_content_width=100)

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -12,43 +12,41 @@ def cli():
 
 
 @cli.command()
-@click.argument("resource_type", default=None, required=False)
-@click.argument("resource_name", default=None, required=False)
+@click.argument("_type", metavar="TYPE", required=True)
+@click.argument("name", default=None, required=False)
 @click.option(
     "--owner",
     default=None,
-    required=False,
     help="Resource owner name. Defaults to current auth identity.",
 )
 @click.option(
     "-s",
     "--status",
-    required=False,
     multiple=True,
     type=click.Choice(ResourceStatus.values()),
     help="Filter resource status by one or more value",
 )
-def resources(
-    resource_type: Optional[str],
-    resource_name: Optional[str] = None,
+def list(
+    _type: Optional[str],
+    name: Optional[str] = None,
     owner: Optional[str] = None,
     status: Optional[List[str]] = None,
 ):
     """
-    List resources belonging to an owner.
+    List objects in saturn.
 
     \b
-    RESOURCE_TYPE (optional):
-        all: List resources of any type (Default)
+    TYPE (required):
+        resource: List any type of resource
         deployment, job, workspace: Filter for resources of a single type
-    RESOURCE_NAME (optional):
+    NAME (optional):
         Filter results by prefix match on name
     """
     client = SaturnConnection()
-    if resource_type == "all":
-        resource_type = None
+    if _type in {"resource", "resources"}:
+        _type = None
     resources = client.list_resources(
-        resource_type, resource_name=resource_name, owner_name=owner, status=status
+        _type, resource_name=name, owner_name=owner, status=status
     )
     print_resource_table(resources)
 
@@ -111,7 +109,7 @@ def logs(
     all_containers: bool = False,
 ):
     """
-    Print resource logs. Defaults to the most recently created pod if POD_NAME is not given.
+    Print logs for a given resource.
 
     \b
     RESOURCE_TYPE (required):

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -126,10 +126,7 @@ def pods(
     "--all-containers",
     default=False,
     is_flag=True,
-    help=(
-        "Print logs for all containers. "
-        "By default, only logs for the main container are shown (or init containers during setup)"
-    ),
+    help="Print logs for all containers.",
 )
 def logs(
     resource_type: str,
@@ -140,6 +137,7 @@ def logs(
 ):
     """
     Print logs for a given resource.
+    By default, only logs for the main container are shown (or init containers during setup)
 
     \b
     RESOURCE_TYPE (required):

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from ruamel.yaml import YAML
 import click
 
@@ -12,27 +13,22 @@ def cli():
 
 @cli.command()
 @click.argument("resource_type")
+@click.argument("resource_name", default=None, required=False)
 @click.option(
     "--owner",
     default=None,
     required=False,
     help="Resource owner name. Defaults to current auth identity.",
 )
-def list(resource_type: str, owner: str = None):
+def list(resource_type: str, resource_name: Optional[str] = None, owner: str = None):
     """
-    List resources belonging to an owner.
+    List resources belonging to an owner. Resources are prefix
+    matched against RESOURCE_NAME, if set.
 
     Resource Types: [workspace, deployment, job]
     """
     client = SaturnConnection()
-    resource_type = ResourceType.lookup(resource_type)
-    resources = []
-    if resource_type == ResourceType.WORKSPACE:
-        resources = client.list_workspaces(owner)
-    if resource_type == ResourceType.JOB:
-        resources = client.list_jobs(owner)
-    if resource_type == ResourceType.DEPLOYMENT:
-        resources = client.list_deployments(owner)
+    resources = client.list_recipes(resource_type, resource_name=resource_name, owner_name=owner)
     print_resource_table(resources)
 
 

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -1,11 +1,10 @@
-import json
 import sys
 from typing import List, Optional
 from ruamel.yaml import YAML
 import click
 
 from saturn_client.cli.utils import OutputFormat, print_pod_table, print_resources
-from saturn_client.core import ResourceStatus, SaturnConnection, ResourceType
+from saturn_client.core import ResourceStatus, SaturnConnection, ResourceType, SaturnHTTPError
 
 
 @click.group()
@@ -185,4 +184,8 @@ def apply(input_file: str, start: bool = False):
 
 
 if __name__ == "__main__":
-    cli(max_content_width=100)
+    try:
+        cli(max_content_width=100)
+    except SaturnHTTPError as e:
+        click.echo("Error: " + str(e))
+        sys.exit(1)

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -181,8 +181,80 @@ def apply(input_file: str, start: bool = False):
     if start:
         resource_type = ResourceType.lookup(result["type"])
         resource_id = result["state"]["id"]
-        client._start(resource_type, resource_id)
+        client.start(resource_type, resource_id)
 
+
+@cli.command()
+@click.argument("resource_type")
+@click.argument("resource_name")
+@click.option(
+    "--owner",
+    default=None,
+    required=False,
+    help="Resource owner name. Defaults to current auth identity.",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help=(
+        "Enable debug mode on the resource. "
+        "This enables SSH, and prevents the container from exiting "
+        "if the main process fails."
+    ),
+)
+def start(resource_type: str, resource_name: str, owner: Optional[str] = None, debug: bool = False):
+    """
+    Start a resource
+
+    \b
+    INPUT_FILE (required):
+        Path to a YAML or JSON recipe file
+    """
+    client = SaturnConnection()
+    resource = client.get_resource(resource_type, resource_name, owner_name=owner)
+    resource_id = resource["state"]["id"]
+    client.start(resource_type, resource_id, debug_mode=debug)
+
+
+@cli.command()
+@click.argument("resource_type")
+@click.argument("resource_name")
+@click.option(
+    "--owner",
+    default=None,
+    required=False,
+    help="Resource owner name. Defaults to current auth identity.",
+)
+def stop(resource_type: str, resource_name: str, owner_name: Optional[str] = None):
+    client = SaturnConnection()
+    resource = client.get_resource(resource_type, resource_name, owner_name=owner_name)
+    resource_id = resource["state"]["id"]
+    client.stop(resource_type, resource_id)
+
+
+@cli.command()
+@click.argument("resource_type")
+@click.argument("resource_name")
+@click.option(
+    "--owner",
+    default=None,
+    required=False,
+    help="Resource owner name. Defaults to current auth identity.",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    help=(
+        "Enable debug mode on the resource. "
+        "This enables SSH, and prevents the container from exiting "
+        "if the main process fails."
+    ),
+)
+def restart(resource_type: str, resource_name: str, owner: Optional[str] = None, debug: bool = False):
+    client = SaturnConnection()
+    resource = client.get_resource(resource_type, resource_name, owner_name=owner)
+    resource_id = resource["state"]["id"]
+    client.restart(resource_type, resource_id, debug_mode=debug)
 
 if __name__ == "__main__":
     try:

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -12,7 +12,7 @@ def cli():
 
 
 @cli.command()
-@click.argument("resource_type")
+@click.argument("resource_type", default=None, required=False)
 @click.argument("resource_name", default=None, required=False)
 @click.option(
     "--owner",
@@ -20,14 +20,17 @@ def cli():
     required=False,
     help="Resource owner name. Defaults to current auth identity.",
 )
-def list(resource_type: str, resource_name: Optional[str] = None, owner: str = None):
+def list(resource_type: Optional[str], resource_name: Optional[str] = None, owner: str = None):
     """
     List resources belonging to an owner. Resources are prefix
     matched against RESOURCE_NAME, if set.
+    Pass "all" into RESOURCE_NAME to list unfiltered by type (default)
 
     Resource Types: [workspace, deployment, job]
     """
     client = SaturnConnection()
+    if resource_type == "all":
+        resource_type = None
     resources = client.list_recipes(resource_type, resource_name=resource_name, owner_name=owner)
     print_resource_table(resources)
 

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -20,11 +20,11 @@ def list(resource_type: str, owner: str = None):
     resource_type = ResourceType.lookup(resource_type)
     resources = []
     if resource_type == ResourceType.WORKSPACE:
-        resources = client.list_workspaces()
+        resources = client.list_workspaces(owner)
     if resource_type == ResourceType.JOB:
-        resources = client.list_jobs()
+        resources = client.list_jobs(owner)
     if resource_type == ResourceType.DEPLOYMENT:
-        resources = client.list_deployments()
+        resources = client.list_deployments(owner)
     print_resource_table(resources)
 
 

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -80,6 +80,7 @@ def get(_type: str, name: str, owner: Optional[str] = None, output: str = Output
     resource = client.get_resource(_type, name, owner_name=owner)
     print_resources(resource, output=output)
 
+
 @cli.command()
 @click.argument("resource_type")
 @click.argument("resource_name")

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -42,32 +42,11 @@ def pods(resource_type: str, name: str, owner: str = None):
 @cli.command()
 @click.argument("resource_type")
 @click.argument("name")
-@click.argument("pod_name")
+@click.argument("pod_name", default=None, required=False)
 @click.option("--owner", default=None, required=False)
-def pod_logs(resource_type: str, name: str, pod_name: str, owner: str = None):
+def logs(resource_type: str, name: str, owner: str = None, pod_name: str = None):
     client = SaturnConnection()
-    resource_type = ResourceType.lookup(resource_type)
-    logs = client.get_pod_logs(resource_type, name, pod_name, owner_name=owner)
-    click.echo(logs)
-
-
-@cli.command()
-@click.argument("resource_type")
-@click.argument("name")
-@click.option("--rank", default=0, required=False)
-@click.option("--owner", default=None, required=False)
-def logs(resource_type: str, name: str, rank: Optional[int] = 0, owner: str = None):
-    client = SaturnConnection()
-    resource_type = ResourceType.lookup(resource_type)
-    if resource_type == ResourceType.WORKSPACE:
-        logs, pod = client.get_workspace_logs(name, owner)
-    elif resource_type == ResourceType.JOB:
-        logs, pod = client.get_job_logs(name, owner, rank=rank)
-    else:
-        logs, pod = client.get_deployment_logs(name, owner, rank=rank)
-
-    click.echo(f"logs for {pod['pod_name']}")
-    click.echo("-" * 100)
+    logs = client.get_logs(resource_type, name, owner_name=owner, pod_name=pod_name)
     click.echo(logs)
 
 
@@ -89,4 +68,4 @@ def apply(input_file: str, start: bool = False):
 
 
 if __name__ == "__main__":
-    cli()
+    cli(max_content_width=100)

--- a/saturn_client/cli/commands.py
+++ b/saturn_client/cli/commands.py
@@ -82,8 +82,8 @@ def apply(input_file: str, start: bool = False):
     client = SaturnConnection()
     result = client.apply(obj)
     if start:
-        resource_type = ResourceType.lookup(result['type'])
-        resource_id = result['state']['id']
+        resource_type = ResourceType.lookup(result["type"])
+        resource_id = result["state"]["id"]
         client._start(resource_type, resource_id)
 
 

--- a/saturn_client/cli/utils.py
+++ b/saturn_client/cli/utils.py
@@ -1,14 +1,16 @@
 import json
 from enum import Enum
-from glob import has_magic
+import sys
 from typing import Any, Dict, List, Optional, Union
 
 import click
+from ruamel.yaml import YAML
 
 
-class OutputFormats(str, Enum):
+class OutputFormat(str, Enum):
     TABLE = "table"
     JSON = "json"
+    YAML = "yaml"
 
     def __str__(self) -> str:
         return str(self.value)
@@ -25,6 +27,23 @@ class OutputFormats(str, Enum):
 
 def print_json(data: Union[List, Dict]):
     click.echo(json.dumps(data, indent=2))
+
+
+def print_resources(resource: Union[List, Dict], output: str = OutputFormat.TABLE):
+    output = output.lower()
+    OutputFormat.validate(output)
+    if output == OutputFormat.TABLE:
+        if not isinstance(resource, list):
+            resource = [resource]
+        print_resource_table(resource)
+    elif output == OutputFormat.YAML:
+        yaml = YAML()
+        if isinstance(resource, list):
+            yaml.dump_all(resource, sys.stdout)
+        else:
+            yaml.dump(resource, sys.stdout)
+    else:
+        print_json(resource)
 
 
 def print_resource_table(

--- a/saturn_client/cli/utils.py
+++ b/saturn_client/cli/utils.py
@@ -33,8 +33,6 @@ def print_resource_table(
     headers = ["owner", "name", "resource_type", "status", "instance_type", "instance_count", "id"]
     data: List[List[str]] = []
     for recipe in results:
-        import pprint
-
         spec = recipe["spec"]
         state = recipe["state"]
         id = state["id"]

--- a/saturn_client/cli/utils.py
+++ b/saturn_client/cli/utils.py
@@ -74,8 +74,8 @@ def print_pod_table(
         pod_name = pod["pod_name"]
         status = pod["status"]
         source = pod["source"]
-        start_time = pod["start_time"]
-        end_time = pod["end_time"] if pod["end_time"] else ""
+        start_time = pod["start_time"] or ""
+        end_time = pod["end_time"] or ""
         data.append([pod_name, status, source, start_time, end_time])
     tabulate(data, headers)
 
@@ -95,6 +95,8 @@ def tabulate(
 
     for row in data:
         for i, value in enumerate(row):
+            if value is None:
+                row[i] = value = ""
             widths[i] = max(widths[i], len(str(value)))
 
     header_format_str = ""

--- a/saturn_client/cli/utils.py
+++ b/saturn_client/cli/utils.py
@@ -113,3 +113,21 @@ def tabulate(
     click.echo("-" * (sum(widths) + rpadding * (len(headers) - 1)))
     for row in data:
         click.echo(format_str.format(*row))
+
+
+def print_resource_op(
+    operation: str,
+    resource_type: str,
+    resource_name: Optional[str] = None,
+    owner_name: Optional[str] = None,
+    *args: str
+):
+    parts = [
+        operation,
+        resource_type,
+        resource_name,
+    ]
+    if owner_name:
+        parts.append(f"for {owner_name}")
+    parts.extend(args)
+    click.echo(" ".join([p for p in parts if p]))

--- a/saturn_client/cli/utils.py
+++ b/saturn_client/cli/utils.py
@@ -47,18 +47,18 @@ def print_resources(resource: Union[List, Dict], output: str = OutputFormat.TABL
 
 
 def print_resource_table(
-    results: List[Dict[str, Any]],
+    resources: List[Dict[str, Any]],
 ):
     headers = ["owner", "name", "resource_type", "status", "instance_type", "instance_count", "id"]
     data: List[List[str]] = []
-    for recipe in results:
-        spec = recipe["spec"]
-        state = recipe["state"]
-        id = state["id"]
-        owner = spec["owner"]
+    for resource in resources:
+        spec = resource["spec"]
+        state = resource.get("state", {})
+        id = state.get("id")
+        owner = spec.get("owner")
         name = spec["name"]
-        resource_type = recipe["type"]
-        status = state["status"]
+        resource_type = resource["type"]
+        status = state.get("status")
         instance_type = spec["instance_type"]
         instance_count = spec.get("instance_count", 1)
         data.append([owner, name, resource_type, status, instance_type, instance_count, id])
@@ -120,7 +120,7 @@ def print_resource_op(
     resource_type: str,
     resource_name: Optional[str] = None,
     owner_name: Optional[str] = None,
-    *args: str
+    *args: str,
 ):
     parts = [
         operation,

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -195,14 +195,16 @@ class SaturnConnection:
 
     def list_recipes(
         self,
-        resource_type: str,
+        resource_type: Optional[str] = None,
         resource_name: Optional[str] = None,
         owner_name: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         next_last_key = None
         recipes = []
-        resource_type = ResourceType.lookup(resource_type)
-        qparams = {"type": resource_type}
+        qparams = {}
+        if resource_type is not None:
+            resource_type = ResourceType.lookup(resource_type)
+            qparams["type"] = resource_type
         if owner_name:
             qparams["owner_name"] = owner_name
         if resource_name:

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -249,18 +249,12 @@ class SaturnConnection:
         return response.json()
 
     def list_deployments(self, owner_name: str = None) -> List[Any]:
-        if owner_name is None:
-            owner_name = self.current_user["username"]
         return self._get_recipes(ResourceType.DEPLOYMENT, owner_name=owner_name)
 
     def list_jobs(self, owner_name: str = None) -> List[Any]:
-        if owner_name is None:
-            owner_name = self.current_user["username"]
         return self._get_recipes(ResourceType.JOB, owner_name=owner_name)
 
     def list_workspaces(self, owner_name: str = None) -> List[Any]:
-        if owner_name is None:
-            owner_name = self.current_user["username"]
         return self._get_recipes(ResourceType.WORKSPACE, owner_name=owner_name)
 
     def _get_resource_by_name(self, resource_type: str, resource_name: str, owner_name: str = None):

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -49,15 +49,11 @@ class ResourceType:
     """Enum for resource_type
 
     All resource models should return one of these as resource.resource_type.
-
-    This currently does not match the resource types in Atlas, but it matches the API we want for users.
-
-    We also avoid using the Enum module to minimize dependencies
     """
 
-    DEPLOYMENT = "Deployment"
-    JOB = "Job"
-    WORKSPACE = "Workspace"
+    DEPLOYMENT = "deployment"
+    JOB = "job"
+    WORKSPACE = "workspace"
 
     @classmethod
     def possible_resource_types(cls) -> str:
@@ -69,24 +65,14 @@ class ResourceType:
         converts from the name of the resource type to the string we use in the urls. Currently
         this is just the lower case value + plural.
         """
-        return cls.get_api_name(resource_type) + "s"
-
-    @classmethod
-    def get_api_name(cls, resource_type: str) -> str:
-        """
-        converts from the name of the resource type to the string we use in the API. Currently
-        this is just the lower case value.
-        """
-        if resource_type not in cls.possible_resource_types():
-            raise SaturnError(f"Invalid resource type {resource_type}")
-        return resource_type.lower()
+        return cls.lookup(resource_type) + "s"
 
     @classmethod
     def lookup(cls, input: str):
         for resource_type in cls.possible_resource_types():
-            if resource_type.lower() == input.lower():
+            if resource_type == input.lower():
                 return resource_type
-        raise SaturnError(f"resource type {input} not found")
+        raise SaturnError(f'resource type "{input}" not found')
 
 
 @dataclass

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -443,3 +443,19 @@ class SaturnConnection:
         if not response.ok:
             raise SaturnHTTPError.from_response(response)
         return response.json()
+
+    def schedule(self, job_id: str, cron_schedule: Optional[str] = None, disable: bool = False):
+        url_name = ResourceType.get_url_name(ResourceType.JOB)
+        base_url = urljoin(self.url, f"api/{url_name}/{job_id}")
+        if cron_schedule:
+            response = requests.patch(
+                base_url, {"cron_schedule_options": {"schedule": cron_schedule}}
+            )
+            if not response.ok:
+                raise SaturnHTTPError.from_response(response)
+
+        url = urljoin(f"{base_url}/", "unschedule" if disable else "schedule")
+        response = requests.post(url, headers=self.settings.headers)
+        if not response.ok:
+            raise SaturnHTTPError.from_response(response)
+        return response.json()

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -193,24 +193,23 @@ class SaturnConnection:
             self._options = response.json()
         return self._options
 
-    def _get_recipes(
+    def list_recipes(
         self,
         resource_type: str,
         resource_name: Optional[str] = None,
         owner_name: Optional[str] = None,
-        max_count=10,
     ) -> List[Dict[str, Any]]:
         next_last_key = None
         recipes = []
         resource_type = ResourceType.lookup(resource_type)
-        qparams = {"type": resource_type, "max_count": max_count}
+        qparams = {"type": resource_type}
         if owner_name:
             qparams["owner_name"] = owner_name
         if resource_name:
             qparams["name"] = resource_name
-        url = urljoin(self.url, "api/recipes")
+        base_url = urljoin(self.url, "api/recipes")
         while True:
-            url = url + "?" + urlencode(qparams)
+            url = base_url + "?" + urlencode(qparams)
             response = requests.get(url, headers=self.settings.headers)
             if not response.ok:
                 raise SaturnHTTPError.from_response(response)
@@ -222,14 +221,14 @@ class SaturnConnection:
             qparams["last_key"] = next_last_key
         return recipes
 
-    def list_deployments(self, owner_name: str = None) -> List[Dict[str, Any]]:
-        return self._get_recipes(ResourceType.DEPLOYMENT, owner_name=owner_name)
+    def list_deployments(self, owner_name: str = None, **kwargs) -> List[Dict[str, Any]]:
+        return self.list_recipes(ResourceType.DEPLOYMENT, owner_name=owner_name, **kwargs)
 
-    def list_jobs(self, owner_name: str = None) -> List[Dict[str, Any]]:
-        return self._get_recipes(ResourceType.JOB, owner_name=owner_name)
+    def list_jobs(self, owner_name: str = None, **kwargs) -> List[Dict[str, Any]]:
+        return self.list_recipes(ResourceType.JOB, owner_name=owner_name, **kwargs)
 
-    def list_workspaces(self, owner_name: str = None) -> List[Dict[str, Any]]:
-        return self._get_recipes(ResourceType.WORKSPACE, owner_name=owner_name)
+    def list_workspaces(self, owner_name: str = None, **kwargs) -> List[Dict[str, Any]]:
+        return self.list_recipes(ResourceType.WORKSPACE, owner_name=owner_name, **kwargs)
 
     def _get_recipe_by_name(
         self, resource_type: str, resource_name: str, owner_name: str = None

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -262,9 +262,7 @@ class SaturnConnection:
             resource_id = resource["state"]["id"]
 
         if pod_name:
-            pod_summary = self._get_pod_runtime_summary(
-                pod_name, resource_id=resource_id
-            )
+            pod_summary = self._get_pod_runtime_summary(pod_name, resource_id=resource_id)
             if is_live(pod_summary):
                 return format_logs(pod_summary, all_containers=all_containers)
             return self._get_historical_pod_logs(resource_type, resource_id, pod_name)
@@ -290,9 +288,7 @@ class SaturnConnection:
     def _get_live_pod_logs(
         self, pod_name: str, resource_id: Optional[str] = None, all_containers: bool = False
     ) -> str:
-        pod_summary = self._get_pod_runtime_summary(
-            pod_name, resource_id=resource_id
-        )
+        pod_summary = self._get_pod_runtime_summary(pod_name, resource_id=resource_id)
         return format_logs(pod_summary, all_containers=all_containers)
 
     def _get_historical_pod_logs(self, resource_type: str, resource_id: str, pod_name: str) -> str:
@@ -364,7 +360,9 @@ class SaturnConnection:
         live_pods = sorted(live_pods, key=lambda x: (x["start_time"], x["pod_name"]), reverse=True)
         return live_pods
 
-    def _get_pod_runtime_summary(self, pod_name: str, resource_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    def _get_pod_runtime_summary(
+        self, pod_name: str, resource_id: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
         url = urljoin(self.url, f"api/pod/namespace/main-namespace/name/{pod_name}/runtimesummary")
         response = requests.get(url, headers=self.settings.headers)
         if not response.ok:

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -9,7 +9,7 @@ import datetime as dt
 from dataclasses import dataclass
 from functools import reduce
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Union
 from urllib.parse import urljoin, urlencode
 
 import requests
@@ -56,7 +56,7 @@ class ResourceType:
     WORKSPACE = "workspace"
 
     @classmethod
-    def possible_resource_types(cls) -> str:
+    def possible_resource_types(cls) -> Set[str]:
         return {cls.DEPLOYMENT, cls.JOB, cls.WORKSPACE}
 
     @classmethod
@@ -69,8 +69,14 @@ class ResourceType:
 
     @classmethod
     def lookup(cls, input: str):
-        for resource_type in cls.possible_resource_types():
-            if resource_type == input.lower():
+        types = cls.possible_resource_types()
+        resource_type = input.lower()
+        if resource_type in types:
+            return resource_type
+        if resource_type.endswith("s"):
+            # Check if input was pluralized
+            resource_type = resource_type[:-1]
+            if resource_type in types:
                 return resource_type
         raise SaturnError(f'resource type "{input}" not found')
 
@@ -193,7 +199,7 @@ class SaturnConnection:
         resource_name: Optional[str] = None,
         owner_name: Optional[str] = None,
         max_count=10,
-    ) -> List[Any]:
+    ) -> List[Dict[str, Any]]:
         next_last_key = None
         recipes = []
         resource_type = ResourceType.lookup(resource_type)
@@ -216,11 +222,17 @@ class SaturnConnection:
             qparams["last_key"] = next_last_key
         return recipes
 
-    def _get_recipe_single(
-        self,
-        resource_type: str,
-        resource_name: str,
-        owner_name: Optional[str] = None,
+    def list_deployments(self, owner_name: str = None) -> List[Dict[str, Any]]:
+        return self._get_recipes(ResourceType.DEPLOYMENT, owner_name=owner_name)
+
+    def list_jobs(self, owner_name: str = None) -> List[Dict[str, Any]]:
+        return self._get_recipes(ResourceType.JOB, owner_name=owner_name)
+
+    def list_workspaces(self, owner_name: str = None) -> List[Dict[str, Any]]:
+        return self._get_recipes(ResourceType.WORKSPACE, owner_name=owner_name)
+
+    def _get_recipe_by_name(
+        self, resource_type: str, resource_name: str, owner_name: str = None
     ) -> Dict[str, Any]:
         resource_type = ResourceType.lookup(resource_type)
         url = urljoin(self.url, f"api/recipes/{resource_type}/{resource_name}")
@@ -234,24 +246,45 @@ class SaturnConnection:
             raise SaturnHTTPError.from_response(response)
         return response.json()
 
-    def list_deployments(self, owner_name: str = None) -> List[Any]:
-        return self._get_recipes(ResourceType.DEPLOYMENT, owner_name=owner_name)
+    def get_logs(self, resource_type: str, resource_name: str, owner_name: Optional[str] = None, pod_name: Optional[str] = None) -> str:
+        resource_type = ResourceType.lookup(resource_type)
+        resource = self._get_recipe_by_name(resource_type, resource_name, owner_name=owner_name)
+        resource_id = resource["state"]["id"]
+        logs: str = ""
+        if pod_name:
+            try:
+                runtime_summary = self._get_pod_runtime_summary(
+                    pod_name,
+                )
+                pod_resource_id = runtime_summary.get("labels", {}).get("saturncloud.io/resource-id")
+                if pod_resource_id != resource_id:
+                    raise ValueError(f"Unable to find matching pod for {resource_type} {resource_name} with name {pod_name}")
+                logs = self._format_logs(runtime_summary)
+            except SaturnHTTPError as e:
+                if e.status_code == 404:
+                    logs = self._get_historical_pod_logs(resource_type, resource_id, pod_name)
+                else:
+                    raise e
+        else:
+            pods = self._get_live_pods(resource_type, resource_id)
+            if len(pods) > 0:
+                pod_name = pods[0]["pod_name"]
+                return self.get_logs(resource_type, resource_name, owner_name=owner_name, pod_name=pod_name)
+            else:
+                historical_pods = self._get_historical_pods(resource_type, resource_id)
+                if len(historical_pods) > 0:
+                    pod_name = historical_pods[0]["pod_name"]
+                    logs = self._get_historical_pod_logs(resource_type, resource_id, pod_name)
 
-    def list_jobs(self, owner_name: str = None) -> List[Any]:
-        return self._get_recipes(ResourceType.JOB, owner_name=owner_name)
-
-    def list_workspaces(self, owner_name: str = None) -> List[Any]:
-        return self._get_recipes(ResourceType.WORKSPACE, owner_name=owner_name)
-
-    def _get_resource_by_name(self, resource_type: str, resource_name: str, owner_name: str = None):
-        return self._get_recipe_single(
-            resource_type, resource_name, owner_name=owner_name
-        )
+        if pod_name and logs:
+            line_break = "=" * 100
+            logs = f"Pod: {pod_name}\n{line_break}\n{logs}"
+        return logs
 
     def get_pods(
-        self, resource_type: str, resource_name: str, owner_name: str = None
+        self, resource_type: str, resource_name: str, owner_name: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        resource = self._get_resource_by_name(resource_type, resource_name, owner_name)
+        resource = self._get_recipe_by_name(resource_type, resource_name, owner_name)
         return self._get_pods(resource_type, resource["state"]["id"])
 
     def _get_pods(self, resource_type: str, resource_id: str) -> List[Dict[str, Any]]:
@@ -308,29 +341,39 @@ class SaturnConnection:
         live_pods = sorted(live_pods, key=lambda x: (x["start_time"], x["pod_name"]), reverse=True)
         return live_pods
 
-    def _get_live_pod_logs(self, pod_name: str) -> str:
+    def _format_logs(self, pod_runtime_summary: Dict[str, Any], all_containers: bool = False) -> str:
+        containers: List[Dict[str, Any]] = []
+        if all_containers:
+            containers.extend(pod_runtime_summary["init_container_summaries"])
+            containers.extend(pod_runtime_summary["container_summaries"])
+        else:
+            # Select only the main container
+            for container in pod_runtime_summary["container_summaries"]:
+                if container["name"] == "main":
+                    containers = [container]
+                    break
+
+        container_logs = []
+        line_break = "-" * 100
+        for container in containers:
+            if "previous" in container and container["previous"]:
+                container_logs.append(
+                    f"Container: {container['previous']['name']} (previous)\n{line_break}"
+                    f"\n{container['previous']['logs']}"
+                )
+            container_logs.append(
+                f"Container: {container['name']}\n{line_break}"
+                f"\n{container['logs']}"
+            )
+
+        return "\n\n".join(container_logs)
+
+    def _get_pod_runtime_summary(self, pod_name: str) -> Dict[str, Any]:
         url = urljoin(self.url, f"api/pod/namespace/main-namespace/name/{pod_name}/runtimesummary")
         response = requests.get(url, headers=self.settings.headers)
         if not response.ok:
             raise SaturnHTTPError.from_response(response)
-        result = response.json()
-        init_previous = [
-            x["previous"]["logs"] for x in result["init_container_summaries"] if x["previous"]
-        ]
-        init_previous_str = "\n".join(init_previous) if init_previous else ""
-        init_logs = [x["logs"] for x in result["init_container_summaries"] if x["logs"]]
-        init_logs_str = "\n".join(init_logs) if init_logs else ""
-        previous = [
-            x["previous"]["logs"]
-            for x in result["container_summaries"]
-            if x["previous"] and x["name"] == "main"
-        ]
-        previous_str = "\n".join(previous) if previous else ""
-        logs = [
-            x["logs"] for x in result["container_summaries"] if x["logs"] and x["name"] == "main"
-        ]
-        logs_str = "\n".join(logs) if logs else ""
-        return init_previous_str + init_logs_str + previous_str + logs_str
+        return response.json()
 
     def _get_historical_pod_logs(self, resource_type: str, resource_id: str, pod_name: str) -> str:
         api_name = ResourceType.get_url_name(resource_type)
@@ -339,99 +382,9 @@ class SaturnConnection:
         if not response.ok:
             raise SaturnHTTPError.from_response(response)
         result = response.json()
-        return result["logs"]
-
-    def get_pod_logs(
-        self,
-        resource_type: str,
-        resource_name: str,
-        pod_name: str,
-        owner_name: Optional[str] = None,
-    ):
-        resource = self._get_resource_by_name(resource_type, resource_name, owner_name=owner_name)
-        resource_id = resource["state"]["id"]
-        live_pods = self._get_live_pods(resource_type, resource_id)
-        found = False
-        for pod in live_pods:
-            if pod["pod_name"] == pod_name:
-                found = True
-        if found:
-            logs = self._get_live_pod_logs(pod_name)
-            return logs
-        return self._get_historical_pod_logs(resource_type, resource_id, pod_name)
-
-    def get_job_logs(
-        self, resource_name: str, owner_name: str = None, rank=0
-    ) -> Tuple[str, Dict[str, Any]]:
-        """
-        This method returns logs for the most recent invocation of the job.
-
-        If you need to access previous runs - you should use get_pod_logs directly
-
-        Returns tuple (logs, pod)
-        """
-        resource_type = ResourceType.JOB
-        resource = self._get_resource_by_name(
-            ResourceType.JOB, resource_name, owner_name=owner_name
-        )
-        resource_id = resource["state"]["id"]
-        pods = self._get_pods(resource_type, resource_id)
-        if len(pods) == 0:
-            return ""
-        most_recent_job_name = pods[0]["label_job_name"]
-        job_pods = [x for x in pods if x["label_job_name"] == most_recent_job_name]
-        found_pod: Optional[Dict[str, Any]] = None
-        for pod in job_pods:
-            _, rank_str, suffix = pod["pod_name"].rsplit("-", 2)
-            rank_int = int(rank_str)
-            if rank_int == rank:
-                found_pod = pod
-        if found_pod is None:
-            raise ValueError(f"could not find job for {most_recent_job_name} with rank {rank}")
-        if found_pod["source"] == "historical":
-            logs = self._get_historical_pod_logs(resource_type, resource_id, found_pod["pod_name"])
-        else:
-            logs = self._get_live_pod_logs(found_pod["pod_name"])
-        return logs, found_pod
-
-    def get_deployment_logs(
-        self, resource_name: str, owner_name: str = None, rank=0
-    ) -> Tuple[str, Dict[str, Any]]:
-        """
-        This method will return all logs for a deployment. Deployment pods are un-ordered. In
-        order to impose a rank, we sort pods by start time.
-        """
-        resource_type = ResourceType.DEPLOYMENT
-        resource = self._get_resource_by_name(resource_type, resource_name, owner_name=owner_name)
-        resource_id = resource["state"]["id"]
-        pods = self._get_pods(resource_type, resource_id)
-        if rank >= len(pods):
-            raise SaturnError(f"could not find pod for {resource_name} with rank {rank}")
-        found_pod = pods[rank]
-        if found_pod["source"] == "historical":
-            logs = self._get_historical_pod_logs(resource_type, resource_id, found_pod["pod_name"])
-        else:
-            logs = self._get_live_pod_logs(found_pod["pod_name"])
-        return logs, found_pod
-
-    def get_workspace_logs(
-        self, resource_name: str, owner_name: str = None
-    ) -> Tuple[str, Dict[str, Any]]:
-        """
-        This method will return all logs for a workspace
-        """
-        resource_type = ResourceType.WORKSPACE
-        resource = self._get_resource_by_name(resource_type, resource_name, owner_name=owner_name)
-        resource_id = resource["state"]["id"]
-        pods = self._get_pods(resource_type, resource_id)
-        if len(pods) == 0:
-            return ""
-        found_pod = pods[0]
-        if found_pod["source"] == "historical":
-            logs = self._get_historical_pod_logs(resource_type, resource_id, found_pod["pod_name"])
-        else:
-            logs = self._get_live_pod_logs(found_pod["pod_name"])
-        return logs, found_pod
+        logs = result["logs"]
+        line_break = "-" * 100
+        return f"Historical\n{line_break}\n{logs}"
 
     def apply(self, recipe_dict: Dict[str, Any]) -> Dict[str, Any]:
         url = urljoin(self.url, "api/recipes")

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -9,7 +9,7 @@ import datetime as dt
 from dataclasses import dataclass
 from functools import reduce
 import requests
-from typing import Any, Dict, Iterable, List, Optional, Set, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 from urllib.parse import urljoin, urlencode
 
 from saturn_client.settings import Settings

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -417,11 +417,28 @@ class SaturnConnection:
         result = response.json()
         return result
 
-    def _start(self, resource_type: str, resource_id: str):
+    def start(self, resource_type: str, resource_id: str, debug_mode: bool = False):
         url_name = ResourceType.get_url_name(resource_type)
         url = urljoin(self.url, f"api/{url_name}/{resource_id}/start")
+        data = {"debug_mode": True} if debug_mode else None
+        response = requests.post(url, headers=self.settings.headers, json=data)
+        if not response.ok:
+            raise SaturnHTTPError.from_response(response)
+        return response.json()
+
+    def stop(self, resource_type: str, resource_id: str):
+        url_name = ResourceType.get_url_name(resource_type)
+        url = urljoin(self.url, f"api/{url_name}/{resource_id}/stop")
         response = requests.post(url, headers=self.settings.headers)
         if not response.ok:
             raise SaturnHTTPError.from_response(response)
-        result = response.json()
-        return result
+        return response.json()
+
+    def restart(self, resource_type: str, resource_id: str, debug_mode: bool = False):
+        url_name = ResourceType.get_url_name(resource_type)
+        url = urljoin(self.url, f"api/{url_name}/{resource_id}/restart")
+        data = {"debug_mode": True} if debug_mode else None
+        response = requests.post(url, headers=self.settings.headers, json=data)
+        if not response.ok:
+            raise SaturnHTTPError.from_response(response)
+        return response.json()

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -292,6 +292,7 @@ class SaturnConnection:
                 owner_name=owner_name,
                 pod_name=pod_name,
                 resource_id=resource_id,
+                all_containers=all_containers,
             )
 
         historical_pods = self._get_historical_pods(resource_type, resource_id)

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -214,6 +214,7 @@ class SaturnConnection:
         resource_type: Optional[str] = None,
         resource_name: Optional[str] = None,
         owner_name: Optional[str] = None,
+        as_template: bool = False,
         status: Optional[Union[str, Iterable[str]]] = None,
     ) -> List[Dict[str, Any]]:
         next_last_key = None
@@ -226,6 +227,8 @@ class SaturnConnection:
             qparams["owner_name"] = owner_name
         if resource_name:
             qparams["name"] = resource_name
+        if as_template:
+            qparams["as_template"] = True
         base_url = urljoin(self.url, "api/recipes")
         while True:
             url = base_url + "?" + urlencode(qparams)
@@ -248,13 +251,19 @@ class SaturnConnection:
         return recipes
 
     def get_resource(
-        self, resource_type: str, resource_name: str, owner_name: str = None
+        self,
+        resource_type: str,
+        resource_name: str,
+        owner_name: str = None,
+        as_template: bool = False,
     ) -> Dict[str, Any]:
         resource_type = ResourceType.lookup(resource_type)
         url = urljoin(self.url, f"api/recipes/{resource_type}/{resource_name}")
         qparams = {}
         if owner_name:
             qparams["owner_name"] = owner_name
+        if as_template:
+            qparams["as_template"] = True
         url = url + "?" + urlencode(qparams)
 
         response = requests.get(url, headers=self.settings.headers)

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -449,7 +449,9 @@ class SaturnConnection:
         base_url = urljoin(self.url, f"api/{url_name}/{job_id}")
         if cron_schedule:
             response = requests.patch(
-                base_url, {"cron_schedule_options": {"schedule": cron_schedule}}
+                base_url,
+                json={"cron_schedule_options": {"schedule": cron_schedule}},
+                headers=self.settings.headers,
             )
             if not response.ok:
                 raise SaturnHTTPError.from_response(response)

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -247,16 +247,7 @@ class SaturnConnection:
             recipes = [r for r in recipes if r.get("state", {}).get("status") in status]
         return recipes
 
-    def list_deployments(self, owner_name: str = None, **kwargs) -> List[Dict[str, Any]]:
-        return self.list_resources(ResourceType.DEPLOYMENT, owner_name=owner_name, **kwargs)
-
-    def list_jobs(self, owner_name: str = None, **kwargs) -> List[Dict[str, Any]]:
-        return self.list_resources(ResourceType.JOB, owner_name=owner_name, **kwargs)
-
-    def list_workspaces(self, owner_name: str = None, **kwargs) -> List[Dict[str, Any]]:
-        return self.list_resources(ResourceType.WORKSPACE, owner_name=owner_name, **kwargs)
-
-    def _get_recipe_by_name(
+    def get_resource(
         self, resource_type: str, resource_name: str, owner_name: str = None
     ) -> Dict[str, Any]:
         resource_type = ResourceType.lookup(resource_type)
@@ -282,7 +273,7 @@ class SaturnConnection:
     ) -> str:
         resource_type = ResourceType.lookup(resource_type)
         if not resource_id:
-            resource = self._get_recipe_by_name(resource_type, resource_name, owner_name=owner_name)
+            resource = self.get_resource(resource_type, resource_name, owner_name=owner_name)
             resource_id = resource["state"]["id"]
 
         if pod_name:
@@ -331,7 +322,7 @@ class SaturnConnection:
         owner_name: Optional[str] = None,
         status: Optional[Union[str, Iterable[str]]] = None,
     ) -> List[Dict[str, Any]]:
-        resource = self._get_recipe_by_name(resource_type, resource_name, owner_name)
+        resource = self.get_resource(resource_type, resource_name, owner_name)
         return self._get_all_pods(resource_type, resource["state"]["id"], status=status)
 
     def _get_all_pods(

--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -134,7 +134,7 @@ class Pod:
     name: str
     status: str
     source: str
-    start_time: str
+    start_time: Optional[str]
     end_time: Optional[str]
 
     @classmethod
@@ -354,7 +354,7 @@ class SaturnConnection:
         result = response.json()["pods"]
         for p in result:
             p["source"] = "historical"
-        result = sorted(result, key=lambda x: (x["start_time"], x["pod_name"]), reverse=True)
+        result = sorted(result, key=lambda x: (x["start_time"] or "", x["pod_name"]), reverse=True)
         return result
 
     def _get_live_pods(self, resource_type: str, resource_id: str) -> List[Dict[str, Any]]:
@@ -373,7 +373,7 @@ class SaturnConnection:
             pod_summaries = result.get("pod_summaries", [])
         for pod in pod_summaries:
             end_time = pod.get("completed_at", "")
-            start_time = pod["started_at"]
+            start_time = pod.get("started_at", "")
             status = pod["status"]
             pod_name = pod["name"]
             last_seen = utcnow()

--- a/saturn_client/logs.py
+++ b/saturn_client/logs.py
@@ -58,14 +58,17 @@ def has_logs(pod_summary: Dict[str, Any]) -> bool:
     return any(c.get("logs") for c in init_containers)
 
 
-def format_container_logs(container_summary: Dict[str, Any], is_previous: bool = False) -> str:
+def format_container_logs(
+    container_summary: Dict[str, Any], is_previous: bool = False, is_init: bool = False
+) -> str:
     label = ""
     if is_previous:
         label = " (previous)"
     logs = container_summary["logs"]
     if not logs:
         logs = f"Status: {container_summary['status']}"
-    logs = _section_header(f"Container: {container_summary['name']}{label}", logs, char="-")
+    header = "Container" if not is_init else "Init Container"
+    logs = _section_header(f"{header}: {container_summary['name']}{label}", logs, char="-")
     finished_at = container_summary.get("finished_at")
     if finished_at:
         finished_at = container_summary["finished_at"]

--- a/saturn_client/logs.py
+++ b/saturn_client/logs.py
@@ -3,9 +3,7 @@ from typing import Any, Dict, List, Optional
 
 def format_logs(pod_summary: Dict[str, Any], all_containers: bool = False) -> str:
     containers: List[Dict[str, Any]] = []
-    init_container_summaries: List[Dict[str, Any]] = pod_summary.get(
-        "init_container_summaries", []
-    )
+    init_container_summaries: List[Dict[str, Any]] = pod_summary.get("init_container_summaries", [])
     container_summaries: List[Dict[str, Any]] = pod_summary.get("container_summaries", [])
     if all_containers:
         containers.extend(init_container_summaries)
@@ -67,9 +65,7 @@ def format_container_logs(container_summary: Dict[str, Any], is_previous: bool =
     logs = container_summary["logs"]
     if not logs:
         logs = f"Status: {container_summary['status']}"
-    logs = _section_header(
-        f"Container: {container_summary['name']}{label}", logs, char="-"
-    )
+    logs = _section_header(f"Container: {container_summary['name']}{label}", logs, char="-")
     finished_at = container_summary.get("finished_at")
     if finished_at:
         finished_at = container_summary["finished_at"]
@@ -83,7 +79,9 @@ def format_historical_logs(pod_name: str, logs: str) -> str:
     return _section_header(f"Pod: {pod_name}", logs)
 
 
-def _format_terminated(logs: str, end_time: str, exit_code: Optional[int] = None, width: int = 100) -> str:
+def _format_terminated(
+    logs: str, end_time: str, exit_code: Optional[int] = None, width: int = 100
+) -> str:
     info = ""
     if exit_code is not None:
         info = f"{exit_code} "

--- a/saturn_client/logs.py
+++ b/saturn_client/logs.py
@@ -1,0 +1,109 @@
+from typing import Any, Dict, List, Optional
+
+
+def format_logs(pod_summary: Dict[str, Any], all_containers: bool = False) -> str:
+    containers: List[Dict[str, Any]] = []
+    init_container_summaries: List[Dict[str, Any]] = pod_summary.get(
+        "init_container_summaries", []
+    )
+    container_summaries: List[Dict[str, Any]] = pod_summary.get("container_summaries", [])
+    if all_containers:
+        containers.extend(init_container_summaries)
+        containers.extend(container_summaries)
+    else:
+        # Find the main container
+        for container in container_summaries:
+            if container["name"] == "main":
+                containers = [container]
+                break
+        if not containers:
+            # If no main container, don't assume anything about which containers are important
+            containers = container_summaries
+
+        # If containers are waiting, init containers may still be running
+        if all(c.get("status") == "waiting" for c in containers):
+            containers = init_container_summaries
+
+    container_logs = []
+    for container in containers:
+        previous_container = container.get("previous")
+        if previous_container:
+            container_logs.append(format_container_logs(previous_container, is_previous=True))
+        container_logs.append(format_container_logs(container))
+
+    logs = "\n\n".join(container_logs)
+    if not logs:
+        logs = f"Status: {pod_summary['status']}"
+    return _section_header(f"Pod: {pod_summary['name']}", logs)
+
+
+def is_live(pod_summary: Optional[Dict[str, Any]]) -> bool:
+    """
+    Return true if the pod summary represents a live pod for log formatting
+
+    When a pod completes and its node shuts down, pods often come back without
+    logs in state "completed".
+    """
+    if not pod_summary:
+        return False
+    if has_logs(pod_summary):
+        return True
+    return pod_summary["status"] not in {"completed", "stopping", "stopped"}
+
+
+def has_logs(pod_summary: Dict[str, Any]) -> bool:
+    containers = pod_summary.get("container_summaries", [])
+    if any(c.get("logs") for c in containers):
+        return True
+
+    init_containers = pod_summary.get("init_container_summaries", [])
+    return any(c.get("logs") for c in init_containers)
+
+
+def format_container_logs(container_summary: Dict[str, Any], is_previous: bool = False) -> str:
+    label = ""
+    if is_previous:
+        label = " (previous)"
+    logs = container_summary["logs"]
+    if not logs:
+        logs = f"Status: {container_summary['status']}"
+    logs = _section_header(
+        f"Container: {container_summary['name']}{label}", logs, char="-"
+    )
+    finished_at = container_summary.get("finished_at")
+    if finished_at:
+        finished_at = container_summary["finished_at"]
+        exit_code = container_summary.get("exit_code")
+        logs = _format_terminated(logs, finished_at, exit_code=exit_code)
+    return logs
+
+
+def format_historical_logs(pod_name: str, logs: str) -> str:
+    logs = _section_header("Historical", logs, char="-")
+    return _section_header(f"Pod: {pod_name}", logs)
+
+
+def _format_terminated(logs: str, end_time: str, exit_code: Optional[int] = None, width: int = 100) -> str:
+    info = ""
+    if exit_code is not None:
+        info = f"{exit_code} "
+    info += f"at {end_time}"
+    footer = f" Terminated {info} "
+    width -= len(footer)
+    if width < 0:
+        width = 0
+    marker = "=" * int(width / 2)
+    end_marker = marker
+    if width % 2 == 1:
+        end_marker += "="
+    return f"{logs}\n{marker}{footer}{end_marker}"
+
+
+def _section_header(label: str, content: str = "", char: str = "=", width: int = 100):
+    return "\n".join(
+        [
+            label,
+            (char * width),
+            content,
+        ]
+    )


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Followups on saturn-client
- Filter resources by owner
- Filter resources by name prefix
- Single logs command (a bit confusing having multiple)
- CLI help text
- List all resource types with keywork "resource"
- Support for resource start/stop/restart
- Support for job scheduling/unscheduling
- Output formatting as table/json/yaml
- Filter for pods/logs from either live or historical sources