### PR TITLE
Remove references to old api token route

### DIFF
--- a/saturn_client/core.py
+++ b/saturn_client/core.py
@@ -192,7 +192,6 @@ class SaturnConnection:
 
     :param url: URL for the SaturnCloud instance.
     :param api_token: API token for authenticating the request to Saturn API.
-        Get from `/api/user/token`
     """
 
     _options = None
@@ -208,7 +207,6 @@ class SaturnConnection:
         :param url: URL for the SaturnCloud instance.
             Example: "https://app.community.saturnenterprise.io"
         :param api_token: API token for authenticating the request to Saturn API.
-            Get from ``/api/user/token``
         """
         self.settings = Settings(url, api_token)
 


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Remove references to old api token route